### PR TITLE
Function to automatically buy in bulk (test)

### DIFF
--- a/fc_main.js
+++ b/fc_main.js
@@ -1806,6 +1806,16 @@ function autoCookie() {
         }
 
         var itemBought = false;
+        
+        //Automatically buy in bulk if setting turned on
+        if (FrozenCookies.autoBulk != 0){
+            if (FrozenCookies.autoBulk == 1){ //Buy x10
+                Game.storeBulkButton(3);
+            }
+            if (FrozenCookies.autoBulk == 2){ //Buy x100
+                Game.storeBulkButton(4);
+            }
+        }
 
         if (FrozenCookies.autoBuy && (Game.cookies >= delay + recommendation.cost) && (FrozenCookies.pastemode || isFinite(nextChainedPurchase().efficiency))) {
             //    if (FrozenCookies.autoBuy && (Game.cookies >= delay + recommendation.cost)) {


### PR DESCRIPTION
Im trying to code a function to auto select buying in bulk that would be really usefull to players with a lot of prestige. When using auto ascend buying x1 my game needs 5:40 mins to get the first HC but on x100 it only needs 0:45.

Please check that I did not write any nonsense as I not yet fully understand how frozen cookies work.