### PR TITLE
Check if game is ready before loading Frozen Cookies, else wait and try again

### DIFF
--- a/fc_userscript_loader.user.js
+++ b/fc_userscript_loader.user.js
@@ -15,7 +15,13 @@
 // Github.io: http://lordshinjo.github.io/FrozenCookies/
 
 function LoadFrozenCookies() {
-    Game.LoadMod('https://rawgit.com/Lordshinjo/FrozenCookies/master/frozen_cookies.js');
+    window.setTimeout(function() {
+        if (Game.ready) {
+            Game.LoadMod('https://rawgit.com/Lordshinjo/FrozenCookies/master/frozen_cookies.js');
+        } else {
+            LoadFrozenCookies();
+        }
+    }, 500);
 }
 
 window.addEventListener("load", LoadFrozenCookies, false);


### PR DESCRIPTION
The game may not be ready when the load event is called, resulting in Frozen Cookies not being loaded.