### PR TITLE
Godzamok Cursor Buy/Sell Spam adjustment

### DIFF
--- a/fc_main.js
+++ b/fc_main.js
@@ -1720,7 +1720,8 @@ function autoGSBuy() {
 }
 
 function autoGodzamokAction() {
-    if (Game.hasGod('ruin') && Game.Objects['Cursor'].amount > 10 && hasClickBuff()) {
+    //Now won't trigger until current Devastation buff expires (i.e. won't rapidly buy & sell cursors throughout Godzamok duration)
+    if (Game.hasGod('ruin') && Game.Objects['Cursor'].amount > 10 && !Game.hasbuff('Devastation') && hasClickBuff()) {
         Game.Objects['Cursor'].sell(Game.Objects['Cursor'].amount);
     }
 }

--- a/fc_main.js
+++ b/fc_main.js
@@ -1721,7 +1721,7 @@ function autoGSBuy() {
 
 function autoGodzamokAction() {
     //Now won't trigger until current Devastation buff expires (i.e. won't rapidly buy & sell cursors throughout Godzamok duration)
-    if (Game.hasGod('ruin') && Game.Objects['Cursor'].amount > 10 && !Game.hasbuff('Devastation') && hasClickBuff()) {
+    if (Game.hasGod('ruin') && Game.Objects['Cursor'].amount > 10 && !Game.hasBuff('Devastation') && hasClickBuff()) {
         Game.Objects['Cursor'].sell(Game.Objects['Cursor'].amount);
     }
 }


### PR DESCRIPTION
It feels weird how Auto-Godzamok + AutoBuy spams buying and selling cursors, this change would prevent trying to sell more cursors until the current Godzamok buff ends. (New here hope I'm doing this right)