### PR TITLE
Add option for "Sane" Auto-Godzamok (+ SL autoharvest)

### DIFF
--- a/cc_upgrade_prerequisites.js
+++ b/cc_upgrade_prerequisites.js
@@ -17,7 +17,7 @@ FrozenCookies.preferenceValues = {
     },
     'stormLimit':{
         'hint':'Choose rate of Golden Cookies clicked per second during Cookie Storms.',
-        'display':['Cookie Storm Limit ON','Cookie Storm Limit OFF'],
+        'display':['Cookie Storm Limit OFF','Cookie Storm Limit ON'],
         'default':0,
         'extras':'<a class="option" id="cookieStormSpeed" onclick="updateSpeed(\'cookieStormSpeed\');">${cookieStormSpeed} clicks/sec</a>'
     },

--- a/cc_upgrade_prerequisites.js
+++ b/cc_upgrade_prerequisites.js
@@ -15,6 +15,12 @@ FrozenCookies.preferenceValues = {
         'display':["Autoclick GC OFF", "Autoclick GC ON"],
         'default':0
     },
+    'stormLimit':{
+        'hint':'Choose rate of Golden Cookies clicked per second during Cookie Storms.',
+        'display':['Cookie Storm Limit ON','Cookie Storm Limit OFF'],
+        'default':0,
+        'extras':'<a class="option" id="cookieStormSpeed" onclick="updateSpeed(\'cookieStormSpeed\');">${cookieStormSpeed} clicks/sec</a>'
+    },
     'autoWrinkler':{
         'hint':'Automatically pop wrinklers efficiently or instantly.',
         'display':['Autopop Wrinklers OFF', 'Autopop Wrinklers Efficiently', 'Autopop Wrinklers Instantly'],

--- a/cc_upgrade_prerequisites.js
+++ b/cc_upgrade_prerequisites.js
@@ -95,8 +95,8 @@ FrozenCookies.preferenceValues = {
         'default':0
     },
     'autoGodzamok':{
-        'hint':'Automatically sell all cursors during Dragonflight and Click Frenzy if you worship Godzamok',
-        'display':['Auto-Godzamok OFF','Auto-Godzamok ON'],
+        'hint':'Automatically sell all cursors during Dragonflight and Click Frenzy if you worship Godzamok ("Sane" prevents rapid buy/sell spam)',
+        'display':['Auto-Godzamok OFF','Auto-Godzamok ON','Auto-Godzamok ON (Sane)'],
         'default':0
     },
     'defaultSeason':{

--- a/cc_upgrade_prerequisites.js
+++ b/cc_upgrade_prerequisites.js
@@ -87,7 +87,8 @@ FrozenCookies.preferenceValues = {
     'showAchievements':{
         'hint':'Show achievement popups',
         'display':['Achievement Popups OFF','Achievement Popups ON'],
-        'default':0,
+        'default':0
+    },
     'numberDisplay':{
         'hint':'Change how numbers are shortened',
         'display':["Raw Numbers","Full Word (million, billion)","Initials (M, B)","SI Units (M, G, T)", "Scientific Notation (6.3e12)"],

--- a/cc_upgrade_prerequisites.js
+++ b/cc_upgrade_prerequisites.js
@@ -85,7 +85,7 @@ FrozenCookies.preferenceValues = {
         'extras':'<a class="option" id="viewStats" onclick="viewStatGraphs();">View Stat Graphs</a>'
     },
     'showAchievements':{
-        'hint':'Show achievement popups',
+        'hint':'Show achievement popups (Kind of broken early game)',
         'display':['Achievement Popups OFF','Achievement Popups ON'],
         'default':0
     },

--- a/cc_upgrade_prerequisites.js
+++ b/cc_upgrade_prerequisites.js
@@ -20,6 +20,11 @@ FrozenCookies.preferenceValues = {
         'display':['Autopop Wrinklers OFF', 'Autopop Wrinklers Efficiently', 'Autopop Wrinklers Instantly'],
         'default':0
     },
+    'autoSL':{
+        'hint':'Automatically harvest sugar lumps when ripe.',
+        'display':["Autoharvest SL OFF", "Autoharvest SL ON"],
+        'default':0
+    },
     'autoReindeer':{
         'hint':'Automatically click reindeer.',
         'display':['Autoclick Reindeer OFF', 'Autoclick Reindeer ON'],

--- a/cc_upgrade_prerequisites.js
+++ b/cc_upgrade_prerequisites.js
@@ -84,6 +84,10 @@ FrozenCookies.preferenceValues = {
         'default':0,
         'extras':'<a class="option" id="viewStats" onclick="viewStatGraphs();">View Stat Graphs</a>'
     },
+    'showAchievements':{
+        'hint':'Show achievement popups',
+        'display':['Achievement Popups OFF','Achievement Popups ON'],
+        'default':0,
     'numberDisplay':{
         'hint':'Change how numbers are shortened',
         'display':["Raw Numbers","Full Word (million, billion)","Initials (M, B)","SI Units (M, G, T)", "Scientific Notation (6.3e12)"],

--- a/fc_main.js
+++ b/fc_main.js
@@ -1875,7 +1875,6 @@ function autoCookie() {
             }
             if (Game.hasBuff('Cookie storm') && FrozenCookies.cookieStormSpeed > 0) {
                 setInterval(popOneGC, 1000/FrozenCookies.cookieStormSpeed);
-                popOneGC();
             }
         }
         if (reindeerLife() > 0 && FrozenCookies.autoReindeer) {
@@ -1929,7 +1928,7 @@ function popOneGC() {
     for (var i in Game.shimmers) {
                 if (Game.shimmers[i].type == 'golden') {
                     Game.shimmers[i].pop();
-                    return;
+                    return 1;
                 }
     }
 }

--- a/fc_main.js
+++ b/fc_main.js
@@ -1928,6 +1928,7 @@ function popOneGC() {
     for (var i in Game.shimmers) {
                 if (Game.shimmers[i].type == 'golden') {
                     Game.shimmers[i].pop();
+                    console.log('PopOne Triggered')
                     return 1;
                 }
     }

--- a/fc_main.js
+++ b/fc_main.js
@@ -27,7 +27,7 @@ function setOverrides() {
     FrozenCookies.cookieClickSpeed = preferenceParse('cookieClickSpeed', 0);
     FrozenCookies.frenzyClickSpeed = preferenceParse('frenzyClickSpeed', 0);
     FrozenCookies.HCAscendAmount = preferenceParse('HCAscendAmount', 0);
-    FrozenCookies.cookieStormSpeed = preferenceParse('cookieStormSpeed', 1);
+    FrozenCookies.cookieStormSpeed = preferenceParse('cookieStormSpeed', 0);
 
     // Becomes 0 almost immediately after user input, so default to 0
     FrozenCookies.timeTravelAmount = 0;

--- a/fc_main.js
+++ b/fc_main.js
@@ -1925,7 +1925,7 @@ function autoCookie() {
 }
 
 function popOneGC() {
-    if (Game.hasBuff('Cookie storm'): {
+    if (Game.hasBuff('Cookie storm') {
         for (var i in Game.shimmers) {
             if (Game.shimmers[i].type == 'golden') {
                 Game.shimmers[i].pop();

--- a/fc_main.js
+++ b/fc_main.js
@@ -1868,8 +1868,9 @@ function autoCookie() {
         if (goldenCookieLife() && FrozenCookies.autoGC) {
             if (!Game.hasBuff('Cookie storm') || FrozenCookies.stormLimit == 0) {
                 for (var i in Game.shimmers) {
-                if (Game.shimmers[i].type == 'golden') {
-                    Game.shimmers[i].pop();
+                    if (Game.shimmers[i].type == 'golden') {
+                        Game.shimmers[i].pop();
+                    }
                 }
             }
             if (Game.hasBuff('Cookie storm') && FrozenCookies.cookieStormSpeed > 0) {

--- a/fc_main.js
+++ b/fc_main.js
@@ -1925,7 +1925,7 @@ function autoCookie() {
 }
 
 function popOneGC() {
-    if (Game.hasBuff('Cookie storm') {
+    if (Game.hasBuff('Cookie storm')) {
         for (var i in Game.shimmers) {
             if (Game.shimmers[i].type == 'golden') {
                 Game.shimmers[i].pop();

--- a/fc_main.js
+++ b/fc_main.js
@@ -27,6 +27,7 @@ function setOverrides() {
     FrozenCookies.cookieClickSpeed = preferenceParse('cookieClickSpeed', 0);
     FrozenCookies.frenzyClickSpeed = preferenceParse('frenzyClickSpeed', 0);
     FrozenCookies.HCAscendAmount = preferenceParse('HCAscendAmount', 0);
+    FrozenCookies.cookieStormSpeed = preferenceParse('cookieStormSpeed', 1);
 
     // Becomes 0 almost immediately after user input, so default to 0
     FrozenCookies.timeTravelAmount = 0;
@@ -1865,10 +1866,15 @@ function autoCookie() {
 
         // This apparently *has* to stay here, or else fast purchases will multi-click it.
         if (goldenCookieLife() && FrozenCookies.autoGC) {
-            for (var i in Game.shimmers) {
+            if (!Game.hasBuff('Cookie storm') || FrozenCookies.stormLimit == 0) {
+                for (var i in Game.shimmers) {
                 if (Game.shimmers[i].type == 'golden') {
                     Game.shimmers[i].pop();
                 }
+            }
+            if (Game.hasBuff('Cookie storm') && FrozenCookies.cookieStormSpeed > 0) {
+                setInterval(popOneGC, 1000/FrozenCookies.cookieStormSpeed);
+                popOneGC();
             }
         }
         if (reindeerLife() > 0 && FrozenCookies.autoReindeer) {
@@ -1918,6 +1924,14 @@ function autoCookie() {
     }
 }
 
+function popOneGC() {
+    for (var i in Game.shimmers) {
+                if (Game.shimmers[i].type == 'golden') {
+                    Game.shimmers[i].pop();
+                    return;
+                }
+    }
+}
 function FCStart() {
     //  To allow polling frequency to change, clear intervals before setting new ones.
 

--- a/fc_main.js
+++ b/fc_main.js
@@ -1925,12 +1925,14 @@ function autoCookie() {
 }
 
 function popOneGC() {
-    for (var i in Game.shimmers) {
-                if (Game.shimmers[i].type == 'golden') {
-                    Game.shimmers[i].pop();
-                    console.log('PopOne Triggered')
-                    return 1;
-                }
+    if (Game.hasBuff('Cookie storm'): {
+        for (var i in Game.shimmers) {
+            if (Game.shimmers[i].type == 'golden') {
+                Game.shimmers[i].pop();
+                console.log('PopOne Triggered')
+                return 1;
+            }
+        }
     }
 }
 function FCStart() {

--- a/fc_main.js
+++ b/fc_main.js
@@ -1720,8 +1720,8 @@ function autoGSBuy() {
 }
 
 function autoGodzamokAction() {
-    //Now won't trigger until current Devastation buff expires (i.e. won't rapidly buy & sell cursors throughout Godzamok duration)
-    if (Game.hasGod('ruin') && Game.Objects['Cursor'].amount > 10 && !Game.hasBuff('Devastation') && hasClickBuff()) {
+    //Now has option to not trigger until current Devastation buff expires (i.e. won't rapidly buy & sell cursors throughout Godzamok duration)
+    if (Game.hasGod('ruin') && Game.Objects['Cursor'].amount > 10 && (!Game.hasBuff('Devastation') || FrozenCookies.autoGodzamok == 1) && hasClickBuff()) {
         Game.Objects['Cursor'].sell(Game.Objects['Cursor'].amount);
     }
 }

--- a/fc_main.js
+++ b/fc_main.js
@@ -1571,6 +1571,8 @@ function fcWin(what) {
                 if (!FrozenCookies.disabledPopups) {
                     logEvent('Achievement', 'Achievement unlocked :<br>' + Game.Achievements[what].name + '<br> ', true);
                 }
+                if (FrozenCookies.showAchievements) {
+                    Game.Notify('Achievement unlocked','<div class="title" style="font-size:18px;margin-top:-2px;">'+name+'</div>',Game.Achievements[what].icon);
                 if (Game.Achievements[what].pool != 'shadow') {
                     Game.AchievementsOwned++;
                 }

--- a/fc_main.js
+++ b/fc_main.js
@@ -1569,7 +1569,7 @@ function fcWin(what) {
             if (Game.Achievements[what].won == 0) {
                 var achname=Game.Achievements[what].shortName?Game.Achievements[what].shortName:Game.Achievements[what].name;
                 Game.Achievements[what].won = 1;
-                logEvent(what + 'achievement set to 1');
+                logEvent(Game.Achievements[what].name + ' won set to ' + Game.Achievements[what].won);
                 if (!FrozenCookies.disabledPopups) {
                     logEvent('Achievement', 'Achievement unlocked :<br>' + Game.Achievements[what].name + '<br> ', true);
                 }

--- a/fc_main.js
+++ b/fc_main.js
@@ -1564,7 +1564,7 @@ function doTimeTravel() {
 }
 
 function fcWin(what) {
-    logEvent('fcWin Called', what)
+    logEvent('fcWin Called' + what)
     if (typeof what === 'string') {
         if (Game.Achievements[what]) {
             if (Game.Achievements[what].won == 0) {

--- a/fc_main.js
+++ b/fc_main.js
@@ -1773,6 +1773,13 @@ function autoCookie() {
         if (FrozenCookies.timeTravelAmount) {
             doTimeTravel();
         }
+        if (FrozenCookies.autoSL) {
+             var started = Game.lumpT;
+             var ripeAge = Game.lumpRipeAge;
+             if ((Date.now() - started) >= ripeAge) {
+                 Game.clickLump();
+             }
+        }
         if (FrozenCookies.autoWrinkler == 1) {
             var popCount = 0;
             var popList = shouldPopWrinklers();

--- a/fc_main.js
+++ b/fc_main.js
@@ -1575,6 +1575,7 @@ function fcWin(what) {
                 if (FrozenCookies.showAchievements) {
                     Game.Notify('Achievement unlocked','<div class="title" style="font-size:18px;margin-top:-2px;">'+achname+'</div>',Game.Achievements[what].icon);
                     logEvent('SHOW ACHIEVEMENTS GOES ONCE')
+                    logEvent(achname)
                 }
                 if (Game.Achievements[what].pool != 'shadow') {
                     Game.AchievementsOwned++;

--- a/fc_main.js
+++ b/fc_main.js
@@ -1720,7 +1720,8 @@ function autoGSBuy() {
 }
 
 function autoGodzamokAction() {
-    if (Game.hasGod('ruin') && Game.Objects['Cursor'].amount > 10 && hasClickBuff()) {
+    //Now won't trigger until current Devastation buff expires (i.e. won't rapidly buy & sell cursors throughout Godzamok duration)
+    if (Game.hasGod('ruin') && Game.Objects['Cursor'].amount > 10 && !Game.hasbuff('Devastation') && hasClickBuff()) {
         Game.Objects['Cursor'].sell(Game.Objects['Cursor'].amount);
     }
 }

--- a/fc_main.js
+++ b/fc_main.js
@@ -102,7 +102,7 @@ function setOverrides() {
     //  if (FrozenCookies.saveWrinklers && localStorage.wrinklers) {
     //    Game.wrinklers = JSON.parse(localStorage.wrinklers);
     //  }
-    Game.Win = fcWin;
+    if (!FrozenCookies.showAchievements) Game.Win = fcWin;
     Game.oldBackground = Game.DrawBackground;
     Game.DrawBackground = function() {
         Game.oldBackground();
@@ -1562,14 +1562,15 @@ function doTimeTravel() {
       }
     */
 }
-//Why the hell is fcWin being called so often? It seems to be getting called repeatedly on the CPS achievements, which should only happen when you actually win them?
+//Why the hell is fcWin being called so often? It seems to be getting called repeatedly on the CPS achievements, 
+//which should only happen when you actually win them?
 function fcWin(what) {
     if (typeof what === 'string') {
         if (Game.Achievements[what]) {
             if (Game.Achievements[what].won == 0) {
                 var achname=Game.Achievements[what].shortName?Game.Achievements[what].shortName:Game.Achievements[what].name;
                 Game.Achievements[what].won = 1;
-                logEvent(Game.Achievements[what].name + ' won set to ' + Game.Achievements[what].won);
+                
                 if (!FrozenCookies.disabledPopups) {
                     logEvent('Achievement', 'Achievement unlocked :<br>' + Game.Achievements[what].name + '<br> ', true);
                 }

--- a/fc_main.js
+++ b/fc_main.js
@@ -1564,12 +1564,12 @@ function doTimeTravel() {
 }
 
 function fcWin(what) {
-    logEvent('fcWin Called' + what)
     if (typeof what === 'string') {
         if (Game.Achievements[what]) {
             if (Game.Achievements[what].won == 0) {
                 var achname=Game.Achievements[what].shortName?Game.Achievements[what].shortName:Game.Achievements[what].name;
                 Game.Achievements[what].won = 1;
+                logEvent(what + 'achievement set to 1')
                 if (!FrozenCookies.disabledPopups) {
                     logEvent('Achievement', 'Achievement unlocked :<br>' + Game.Achievements[what].name + '<br> ', true);
                 }

--- a/fc_main.js
+++ b/fc_main.js
@@ -1567,12 +1567,13 @@ function fcWin(what) {
     if (typeof what === 'string') {
         if (Game.Achievements[what]) {
             if (Game.Achievements[what].won == 0) {
+                var achname=Game.Achievements[what].shortName?Game.Achievements[what].shortName:Game.Achievements[what].name;
                 Game.Achievements[what].won = 1;
                 if (!FrozenCookies.disabledPopups) {
                     logEvent('Achievement', 'Achievement unlocked :<br>' + Game.Achievements[what].name + '<br> ', true);
                 }
                 if (FrozenCookies.showAchievements) {
-                    Game.Notify('Achievement unlocked','<div class="title" style="font-size:18px;margin-top:-2px;">'+name+'</div>',Game.Achievements[what].icon);
+                    Game.Notify('Achievement unlocked','<div class="title" style="font-size:18px;margin-top:-2px;">'+achname+'</div>',Game.Achievements[what].icon);
                 }
                 if (Game.Achievements[what].pool != 'shadow') {
                     Game.AchievementsOwned++;

--- a/fc_main.js
+++ b/fc_main.js
@@ -1564,6 +1564,7 @@ function doTimeTravel() {
 }
 
 function fcWin(what) {
+    logEvent('fcWin Called')
     if (typeof what === 'string') {
         if (Game.Achievements[what]) {
             if (Game.Achievements[what].won == 0) {
@@ -1572,11 +1573,9 @@ function fcWin(what) {
                 if (!FrozenCookies.disabledPopups) {
                     logEvent('Achievement', 'Achievement unlocked :<br>' + Game.Achievements[what].name + '<br> ', true);
                 }
-                if (FrozenCookies.showAchievements) {
-                    Game.Notify('Achievement unlocked','<div class="title" style="font-size:18px;margin-top:-2px;">'+achname+'</div>',Game.Achievements[what].icon);
-                    logEvent('SHOW ACHIEVEMENTS GOES ONCE')
-                    logEvent(achname)
-                }
+                //if (FrozenCookies.showAchievements) {
+                //    Game.Notify('Achievement unlocked','<div class="title" style="font-size:18px;margin-top:-2px;">'+achname+'</div>',Game.Achievements[what].icon);
+                //}
                 if (Game.Achievements[what].pool != 'shadow') {
                     Game.AchievementsOwned++;
                 }

--- a/fc_main.js
+++ b/fc_main.js
@@ -1573,6 +1573,7 @@ function fcWin(what) {
                 }
                 if (FrozenCookies.showAchievements) {
                     Game.Notify('Achievement unlocked','<div class="title" style="font-size:18px;margin-top:-2px;">'+name+'</div>',Game.Achievements[what].icon);
+                }
                 if (Game.Achievements[what].pool != 'shadow') {
                     Game.AchievementsOwned++;
                 }

--- a/fc_main.js
+++ b/fc_main.js
@@ -1574,6 +1574,7 @@ function fcWin(what) {
                 }
                 if (FrozenCookies.showAchievements) {
                     Game.Notify('Achievement unlocked','<div class="title" style="font-size:18px;margin-top:-2px;">'+achname+'</div>',Game.Achievements[what].icon);
+                    logEvent('SHOW ACHIEVEMENTS GOES ONCE')
                 }
                 if (Game.Achievements[what].pool != 'shadow') {
                     Game.AchievementsOwned++;

--- a/fc_main.js
+++ b/fc_main.js
@@ -1721,7 +1721,7 @@ function autoGSBuy() {
 
 function autoGodzamokAction() {
     //Now won't trigger until current Devastation buff expires (i.e. won't rapidly buy & sell cursors throughout Godzamok duration)
-    if (Game.hasGod('ruin') && Game.Objects['Cursor'].amount > 10 && !Game.hasbuff('Devastation') && hasClickBuff()) {
+    if (Game.hasGod('ruin') && Game.Objects['Cursor'].amount > 10 && !Game.hasBuff('Devastation') && hasClickBuff()) {
         Game.Objects['Cursor'].sell(Game.Objects['Cursor'].amount);
     }
 }

--- a/fc_main.js
+++ b/fc_main.js
@@ -1562,14 +1562,14 @@ function doTimeTravel() {
       }
     */
 }
-
+//Why the hell is fcWin being called so often? It seems to be getting called repeatedly on the CPS achievements, which should only happen when you actually win them?
 function fcWin(what) {
     if (typeof what === 'string') {
         if (Game.Achievements[what]) {
             if (Game.Achievements[what].won == 0) {
                 var achname=Game.Achievements[what].shortName?Game.Achievements[what].shortName:Game.Achievements[what].name;
                 Game.Achievements[what].won = 1;
-                logEvent(what + 'achievement set to 1')
+                logEvent(what + 'achievement set to 1');
                 if (!FrozenCookies.disabledPopups) {
                     logEvent('Achievement', 'Achievement unlocked :<br>' + Game.Achievements[what].name + '<br> ', true);
                 }
@@ -1583,6 +1583,7 @@ function fcWin(what) {
             }
         }
     } else {
+        logEvent('fcWin Else condition');
         for (var i in what) {
             Game.Win(what[i]);
         }

--- a/fc_main.js
+++ b/fc_main.js
@@ -1570,7 +1570,10 @@ function fcWin(what) {
             if (Game.Achievements[what].won == 0) {
                 var achname=Game.Achievements[what].shortName?Game.Achievements[what].shortName:Game.Achievements[what].name;
                 Game.Achievements[what].won = 1;
-                
+                //This happens a ton of times on CPS achievements; it seems like they would be CHECKED for, but a degbug message placed
+                //here gets repeatedly called seeming to indicate that the achievements.won value is 1, even though the achievement isn't
+                //being unlocked. This also means that placing a function to log the achievement spams out messages. Are the Achievement.won
+                //values being turned off before the game checks again? There must be some reason Game.Win is replaced with fcWin
                 if (!FrozenCookies.disabledPopups) {
                     logEvent('Achievement', 'Achievement unlocked :<br>' + Game.Achievements[what].name + '<br> ', true);
                 }

--- a/fc_main.js
+++ b/fc_main.js
@@ -1564,7 +1564,7 @@ function doTimeTravel() {
 }
 
 function fcWin(what) {
-    logEvent('fcWin Called')
+    logEvent('fcWin Called', what)
     if (typeof what === 'string') {
         if (Game.Achievements[what]) {
             if (Game.Achievements[what].won == 0) {


### PR DESCRIPTION
Adds a toggle in the "Auto-Godzamok" option to not sell more cursors until current Devastation buff ends. Also copied over Phoenix09's auto-lump harvesting change. Seems like there's probably a more legitimate way I should have done that than copy pasting their code but I'm still very new here, apologies.